### PR TITLE
Fix first install 10m delay

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,6 +205,17 @@ table inet filter {
 		elements = { 255.255.255.255, 224.0.0.1, 224.0.0.251}
 	}
 
+	set in_tcp_accept {
+		type inet_service
+		flags interval
+		elements = { ssh}
+	}
+
+	set in_udp_accept {
+		type inet_service
+		flags interval
+	}
+
 	set out_tcp_accept {
 		type inet_service
 		flags interval
@@ -236,6 +247,7 @@ table inet filter {
 		jump global
 		oif "lo" accept
 		ip protocol icmp accept
+		ip6 nexthdr ipv6-icmp counter packets 0 bytes 0 accept
 		udp dport @out_udp_accept ct state new accept
 		tcp dport @out_tcp_accept ct state new accept
 	}

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -133,3 +133,41 @@
   when: (nft_enabled|bool and
          nft_service_manage|bool)
   notify: ['Restart nftables service']
+
+# Enable the following 4 tasks when the service file was installed as a way
+# to detect the first nftable activation (which triggers the 10 min hold bug)
+
+# First ensure the unit is loaded in systemd
+- name: Reload the systemd configuration if nftables unit changed
+  systemd:
+    daemon_reload: yes
+  when: nftables__register_systemd_service.changed | default(False)
+
+# Start nftable service manually here after a 1 sec delay to allow
+# disconnecting properly before the firewall starts.
+# Note: `systemctl enable` is left to the 'Restart nftables service' handler
+- name: Restart nftables service
+  shell: "/bin/sleep 1; /bin/systemctl restart {{ nft_service_name }}"
+  when: ansible_service_mgr == 'systemd' and nft_service_manage
+    and nftables__register_systemd_service.changed | default(False)
+  async: 1000
+  poll: 0
+  register: nftables__register_systemd_service_start_async
+
+# Kill the ssh connection before nftable is restarted (ie during the delay)
+- name: Force ssh to establish a new connection (even with pipelining)
+  meta: reset_connection
+  # disabled because of https://github.com/ansible/ansible/issues/46275
+  # when: nftables__register_systemd_service_start_async.ansible_job_id is defined
+
+# Reestablish the ssh connection and check for the finished restart job.
+- name: Wait for nftables service to be restarted
+  async_status:
+    jid: "{{ nftables__register_systemd_service_start_async.ansible_job_id }}"
+  register: job_result
+  until: job_result.finished
+  retries: 60
+  delay: 2
+  when: nftables__register_systemd_service_start_async.ansible_job_id is defined
+
+#


### PR DESCRIPTION
Hello,

First some doc update, the missing `in_tcp_accept` was bothering me until I ran the command and find out that the doc was missing some of it's output ;)

Second I implemented a way to fix your 10 minutes delay. (https://git.ipr.univ-rennes1.fr/cellinfo/ansible.nftables/issues/1)

This still needs polishing especially to detect the first installation to trigger the extra logic but I got the 10 minutes reduced to 2 seconds ;)

I'll probably update the PR with the extra logic but I though I'd send you this first draft in a "Release early - Release often" spirit !

Best Regards