### PR TITLE
Fix deprecation warning with ansible 2.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@
 * Clean tasks name and comments in tasks/main.yml file.
 * Order and clean comments in defaults/main.yml file.
 
+### Fix
+* Fix deprecation warning with ansible 2.7: Invoking "apt" only once while
+  using a loop via squash_actions is deprecated.
+
 ## v1.5.0
 
 ### Enhancements

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,20 +13,16 @@
 # Manage packages [[[1
 - name: Ensure Nftables packages are in there desired state
   package:
-    name: '{{ item }}'
+    name: '{{ nft_pkg_list | list }}'
     state: '{{ nft_pkg_state }}'
-  with_items:
-    - '{{ nft_pkg_list | to_nice_json }}'
   register: pkg_install_result
   until: pkg_install_result is success
   when: nft_enabled|bool
 
 - name: Ensure old Iptables packages are in there desired state
   apt:
-    name: '{{ item }}'
+    name: '{{ nft_old_pkg_list | list }}'
     state: '{{ nft_old_pkg_state }}'
-  with_items:
-    - '{{ nft_old_pkg_list | to_nice_json }}'
   register: pkg_remove_result
   until: pkg_remove_result is success
   when: (nft_enabled|bool and


### PR DESCRIPTION
Ansible 2.7 complains with the following warning:
```
[DEPRECATION WARNING]: Invoking "apt" only once while using a loop via squash_actions
 is deprecated. Instead of using a loop to supply multiple items and specifying 
`name: {{ item }}`, please use `name: [u'{{ nft_old_pkg_list }}']` and remove the 
loop. This feature will be removed in version 2.11. Deprecation warnings can be 
disabled by setting deprecation_warnings=False in ansible.cfg.
```

This fixes it.