### PR TITLE
Manage empty vars or none value

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -213,6 +213,7 @@ nft_set_default:
     - elements = $in_tcp_accept
   in_udp_accept:
     - type inet_service; flags interval;
+    - elements = $in_udp_accept
   out_tcp_accept:
     - type inet_service; flags interval;
     - elements = $out_tcp_accept

--- a/templates/etc/nftables.d/defines.j2
+++ b/templates/etc/nftables.d/defines.j2
@@ -1,0 +1,7 @@
+{% set definemerged = nft_define_default.copy() %}
+{% set _ = definemerged.update(nft_define) %}
+{% set _ = definemerged.update(nft_define_group) %}
+{% if nft_merged_groups and hostvars[inventory_hostname]['nft_combined_rules'].nft_define_group is defined%}
+  {% set _ = definemerged.update(hostvars[inventory_hostname]['nft_combined_rules'].nft_define_group) %}
+{% endif %}
+{% set _ = definemerged.update(nft_define_host) %}

--- a/templates/etc/nftables.d/defines.nft.j2
+++ b/templates/etc/nftables.d/defines.nft.j2
@@ -1,19 +1,17 @@
 #jinja2: lstrip_blocks: "True", trim_blocks: "True"
 # {{ ansible_managed }}
-{% set definemerged = nft_define_default.copy() %}
-{% set _ = definemerged.update(nft_define) %}
-{% set _ = definemerged.update(nft_define_group) %}
-{% if nft_merged_groups and hostvars[inventory_hostname]['nft_combined_rules'].nft_define_group is defined%}
-  {% set _ = definemerged.update(hostvars[inventory_hostname]['nft_combined_rules'].nft_define_group) %}
-{% endif %}
-{% set _ = definemerged.update(nft_define_host) %}
+{% from './templates/etc/nftables.d/defines.j2' import definemerged with context %}
 
 {% for definition in definemerged.values() %}
-  {% if definition.desc is defined %}
+  {% if definition.value is defined %}
+    {% if definition.value != 'none' %}
+      {% if definition.desc is defined %}
 # {{ definition.desc }}
-  {% else %}
+      {% else %}
 # {{ definition.name }}
-  {% endif %}
+      {% endif %}
 define {{ definition.name }} = {{ definition.value }}
+    {% endif %}
+  {% endif %}
 
 {% endfor %}

--- a/templates/etc/nftables.d/filter-input.nft.j2
+++ b/templates/etc/nftables.d/filter-input.nft.j2
@@ -1,5 +1,6 @@
 #jinja2: lstrip_blocks: "True", trim_blocks: "True"
 # {{ ansible_managed }}
+{% from './templates/etc/nftables.d/defines.j2' import definemerged with context %}
 {% set inputmerged = nft_input_default_rules.copy() %}
 {% set _ = inputmerged.update(nft_input_rules) %}
 {% set _ = inputmerged.update(nft_input_group_rules) %}
@@ -9,13 +10,21 @@
 {% set _ = inputmerged.update(nft_input_host_rules) %}
 
 chain input {
-{% for group, rules in inputmerged|dictsort  %}
-	# {{ group }}
-  {% if not rules %}
-	# (none)
-  {% endif %}
-  {% for rule in rules %}
-	{{ rule }}
+{% for group, rules in inputmerged|dictsort %}
+  {% for def in definemerged if definemerged[def].value is defined %}
+    {% if definemerged[def].value == 'none' %}
+      {% set skipempty = true %}
+    {% endif %}
+    {% set searchstr = '\@' ~ definemerged[def].name %}
+    {% if not rules | select('search', searchstr ) and skipempty is true %}
+    # {{ group }}
+      {% if not rules %}
+    # (none)
+      {% endif %}
+      {% for rule in rules %}
+    {{ rule }}
+      {% endfor %}
+    {% endif %}
   {% endfor %}
 {% endfor %}
 }

--- a/templates/etc/nftables.d/sets.nft.j2
+++ b/templates/etc/nftables.d/sets.nft.j2
@@ -1,5 +1,6 @@
 #jinja2: lstrip_blocks: "True", trim_blocks: "True"
 # {{ ansible_managed }}
+{% from './templates/etc/nftables.d/defines.j2' import definemerged with context %}
 {% set setmerged = nft_set_default.copy() %}
 {% set _ = setmerged.update(nft_set) %}
 {% set _ = setmerged.update(nft_set_group) %}
@@ -8,13 +9,21 @@
 {% endif %}
 {% set _ = setmerged.update(nft_set_host) %}
 
-{% for set, rules in setmerged|dictsort  %}
-  {% if rules %}
+{% for def in definemerged %}
+  {% set searchstr = '\$' ~ definemerged[def].name %}
+  {% if definemerged[def].value is defined %}
+    {% if definemerged[def].value != 'none' %}
+      {% for set, rules in setmerged|dictsort  %}
+        {% if rules %}
+          {% if rules | select('search', searchstr ) %}
 set {{ set }} {
-    {% for rule in rules %}
+            {% for rule in rules %}
 	{{ rule }}
-    {% endfor %}
+            {% endfor %}
 }
+          {% endif %}
+        {% endif %}
+      {% endfor %}
+    {% endif %}
   {% endif %}
-
 {% endfor %}


### PR DESCRIPTION
in_udp_accept did not have the "elements" line needed to actually apply any ports added to the defined list.
Simply adding the line (and probably why it was removed) led to nftables errors though, as "none" is not a valid choice for a define.
To fix this, logic to filter out any empty or 'none' defines was added.

This allows defines to be either empty or in the 'none' state, as it was in the project/readme/defaults.
For example:
```
  input udp accepted:
    name: in_udp_accept
    value: 'none'
```

Signed-off-by: Philipp Rintz <git@rintz.net>