### PR TITLE
Make config backup configurable

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -529,5 +529,17 @@ nft__fail2ban_service: False
 # More verbose output.
 nft_debug: False
 
+# .. envvar:: nft_backup_conf [[[
+#
+# If the nftables config files should be backuped when changed ?
+# Possible options are:
+#
+# ``True``
+#   Default. Backup all nftables config files inside the nftables directory.
+#
+# ``False``
+#   Configs will not be backuped.
+nft_backup_conf: True
+                                                                   # ]]]
                                                                    # ]]]
                                                                    # ]]]

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -81,7 +81,7 @@
     owner: root
     group: root
     mode: 0755
-    backup: yes
+    backup: "{{ nft_backup_conf }}"
   notify: ['Reload nftables service']
   when: nft_enabled|bool
 
@@ -92,7 +92,7 @@
     owner: root
     group: root
     mode: 0755
-    backup: yes
+    backup: "{{ nft_backup_conf }}"
   notify: ['Reload nftables service']
   when: nft_enabled|bool
 
@@ -103,7 +103,7 @@
     owner: root
     group: root
     mode: 0755
-    backup: yes
+    backup: "{{ nft_backup_conf }}"
   notify: ['Reload nftables service']
   when: nft_enabled|bool
 
@@ -115,7 +115,7 @@
     owner: root
     group: root
     mode: 0755
-    backup: yes
+    backup: "{{ nft_backup_conf }}"
   notify: ['Reload nftables service']
   when: nft_enabled|bool
 
@@ -126,7 +126,7 @@
     owner: root
     group: root
     mode: 0755
-    backup: yes
+    backup: "{{ nft_backup_conf }}"
   notify: ['Reload nftables service']
   when: nft_enabled|bool
 
@@ -138,7 +138,7 @@
     owner: root
     group: root
     mode: 0755
-    backup: yes
+    backup: "{{ nft_backup_conf }}"
   notify: ['Reload nftables service']
   when: (nft_enabled|bool and
          nft__nat_table_manage|bool)
@@ -150,7 +150,7 @@
     owner: root
     group: root
     mode: 0755
-    backup: yes
+    backup: "{{ nft_backup_conf }}"
   notify: ['Reload nftables service']
   when: (nft_enabled|bool and
          nft__nat_table_manage|bool)
@@ -167,3 +167,4 @@
   when: (nft_enabled|bool and
          nft_service_manage|bool)
   notify: ['Restart nftables service']
+


### PR DESCRIPTION
This PR makes the config backup creation configurable by introducing the `nft_backup_conf` variable.

Its 'true' by default, just as it was before.
If set to 'false' the configs will not be backuped if changed.