### PR TITLE
Manage nat rules for the `inet` family instead of the `ip` family.

### DIFF
--- a/templates/etc/nftables.conf.j2
+++ b/templates/etc/nftables.conf.j2
@@ -45,7 +45,7 @@ table inet filter {
 
 {% if nft__nat_table_manage %}
 # Additionnal table for Network Address Translation (NAT)
-table ip nat {
+table inet nat {
 	include "{{ nft_set_conf_path }}"
 	include "{{ nft__nat_prerouting_conf_path }}"
 	include "{{ nft__nat_postrouting_conf_path }}"


### PR DESCRIPTION
In some cases, you also need the nat table for ipv6 rules.