### PR TITLE
Run in network-online target

### DIFF
--- a/templates/lib/systemd/system/nftables.service.j2
+++ b/templates/lib/systemd/system/nftables.service.j2
@@ -23,4 +23,4 @@ ExecStop=/usr/sbin/nft flush ruleset
 {% endif %}
 
 [Install]
-WantedBy=multi-user.target
+WantedBy=network-online.target


### PR DESCRIPTION
The `network-online.target` happens before `multi-user.target` and all daemons are already started, so we need to start it as soon as possible to avoid period when firewall is all open.