### PR TITLE
Adding support for Gentoo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 * New rules (disable by default) can be define in *forward* chain (thanks to
   @p-rintz − PR #14).
 * Possibility to toggle file's backup (thanks to @p-rintz − PR #15).
+* Gentoo-specific variables
+* Ability to specify nft binary path through **nft__bin_location**
 
 ### Removed
 * Remove everything related to **in_udp_accept** (see conversation in PR #13).

--- a/README.md
+++ b/README.md
@@ -89,6 +89,7 @@ complexify his philosophy… (I'm pretty sure, i now did complexify it :D) ^^
 Please see default value by Operating System file in [vars][vars directory] directory.
 
 * **nft_pkg_list** : The list of package(s) to provide `nftables`.
+* **nft__bin_location** : Path to `nftables` executable. [default : `/usr/sbin/nft`]
 
 ### Rules Dictionaries
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -599,3 +599,13 @@ nft_backup_conf: True
                                                                    # ]]]
                                                                    # ]]]
                                                                    # ]]]
+# OS specific variables defaults [[[
+# ----------------------------------
+
+# .. envvar:: nft__bin_location [[[
+#
+# Specify Nftables executable location.
+#
+nft__bin_location: '/usr/sbin/nft'
+                                                                   # ]]]
+                                                                   # ]]]

--- a/templates/etc/nftables.conf.j2
+++ b/templates/etc/nftables.conf.j2
@@ -1,5 +1,5 @@
 #jinja2: lstrip_blocks: "True", trim_blocks: "True"
-#!/usr/sbin/nft -f
+#!{{ nft__bin_location }} -f
 # {{ ansible_managed }}
 {% set globalmerged = nft_global_default_rules.copy() %}
 {% set _ = globalmerged.update(nft_global_rules) %}

--- a/templates/lib/systemd/system/nftables.service.j2
+++ b/templates/lib/systemd/system/nftables.service.j2
@@ -13,13 +13,13 @@ ProtectSystem=full
 ProtectHome=true
 {% endif %}
 {% if nft__fail2ban_service %}
-ExecStart=/usr/sbin/nft -f {{ nft_main_conf_path }} ; /bin/systemctl restart fail2ban.service
-ExecReload=/usr/sbin/nft -f {{ nft_main_conf_path }} ; /bin/systemctl restart fail2ban.service
-ExecStop=/bin/systemctl stop fail2ban.service ; /usr/sbin/nft flush ruleset
+ExecStart={{ nft__bin_location }} -f {{ nft_main_conf_path }} ; /bin/systemctl restart fail2ban.service
+ExecReload={{ nft__bin_location }} -f {{ nft_main_conf_path }} ; /bin/systemctl restart fail2ban.service
+ExecStop=/bin/systemctl stop fail2ban.service ; {{ nft__bin_location }} flush ruleset
 {% else %}
-ExecStart=/usr/sbin/nft -f {{ nft_main_conf_path }}
-ExecReload=/usr/sbin/nft -f {{ nft_main_conf_path }}
-ExecStop=/usr/sbin/nft flush ruleset
+ExecStart={{ nft__bin_location }} -f {{ nft_main_conf_path }}
+ExecReload={{ nft__bin_location }} -f {{ nft_main_conf_path }}
+ExecStop={{ nft__bin_location }} flush ruleset
 {% endif %}
 
 [Install]

--- a/vars/gentoo.yml
+++ b/vars/gentoo.yml
@@ -2,3 +2,4 @@
 # vars file for Gentoo
 nft_pkg_list:
   - net-firewall/nftables
+nft__bin_location: "/sbin/nft"

--- a/vars/gentoo.yml
+++ b/vars/gentoo.yml
@@ -1,0 +1,4 @@
+---
+# vars file for Gentoo
+nft_pkg_list:
+  - net-firewall/nftables


### PR DESCRIPTION
Hi!

My Ansible inventory consists of (predominantly) Gentoo machines. I have made a couple of adjustments to the role to add Gentoo support.

* Added Gentoo package name in variables
* Added configurable path for the nft binary. Gentoo installs it into `/sbin` instead of `/usr/sbin`

I see #20 touches the same unit files, I will keep an eye out for its merge and will rebase this PR when it makes sense.

On the general subject of Gentoo support:
The package provides a basic systemd file to store and restore the rules.

```
[Unit]
Description=Store and restore nftables firewall rules
ConditionPathExists=/var/lib/nftables/rules-save
Before=network-pre.target
Wants=network-pre.target

[Service]
Type=oneshot
RemainAfterExit=yes
ExecStart=/usr/libexec/nftables/nftables.sh load /var/lib/nftables/rules-save
ExecStop=/usr/libexec/nftables/nftables.sh store /var/lib/nftables/rules-save

[Install]
WantedBy=basic.target
```
Would it make sense to check that it is disabled in the role, since the role effectively provides own systemd units?