### PR TITLE
Added molecule tests for Gentoo

### DIFF
--- a/molecule/gentoo/Dockerfile.j2
+++ b/molecule/gentoo/Dockerfile.j2
@@ -1,0 +1,5 @@
+FROM gentoo/stage3:systemd
+ENV container=docker
+
+VOLUME ["/sys/fs/cgroup"]
+CMD ["/sbin/init"]

--- a/molecule/gentoo/converge.yml
+++ b/molecule/gentoo/converge.yml
@@ -1,0 +1,9 @@
+---
+- name: Converge
+  hosts: all
+  gather_facts: yes
+  roles:
+    - role: ipr-cnrs.nftables
+      nft_debug: true
+      # can't remove iptables on an instance with docker
+      nft_old_pkg_manage: false

--- a/molecule/gentoo/molecule.yml
+++ b/molecule/gentoo/molecule.yml
@@ -1,0 +1,21 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+platforms:
+  - name: Gentoo
+    image: gentoo/stage3:systemd
+    command: /sbin/init
+    privileged: true
+    volumes:
+      - /srv/gentoo-molecule/gentoo-repo:/var/db/repos/gentoo
+      - /srv/gentoo-molecule/binpkgs:/var/cache/binpkgs
+      - /sys/fs/cgroup:/sys/fs/cgroup:ro
+    tmpfs:
+      - /run
+      - /tmp
+provisioner:
+  name: ansible
+verifier:
+  name: ansible

--- a/molecule/gentoo/prepare.yml
+++ b/molecule/gentoo/prepare.yml
@@ -1,0 +1,34 @@
+# Taken from https://github.com/VTimofeenko/portage-overlay-cfg on commit d8914035e236c4f3819985098dd1ae36551bfc52
+# If bugs are found – check that repository
+# Since Gentoo builds from source, to save time on molecule tests, we should reuse artifacts as much as possible
+# This playbook performs the initial setup of a Gentoo container
+# It configures portage to try to use prebuilt packages if available and to save the built packages.
+---
+- name: Run preparation playbook
+  hosts: Gentoo
+  tasks:
+    - name: Enable buildpkg feature
+      lineinfile:
+        line: "FEATURES='buildpkg'"
+        dest: /etc/portage/make.conf
+        state: present
+    - name: Enable trying to install from binpkgs by default
+      lineinfile:
+        line: "EMERGE_DEFAULT_OPTS='--usepkg'"
+        dest: /etc/portage/make.conf
+        state: present
+    - name: Synchronize gentoo repository if needed
+      block:
+        - name: Check if there is anything in the repo
+          find:
+            paths: '/var/db/repos/gentoo/'
+          register: find_files_in_repo
+        - name: Synchronize the repo if needed
+          command: "emaint sync -a"
+          when: find_files_in_repo.matched == 0
+
+    - name: Install equery, needed for package check
+      # Command, because equery does not exist yet
+      command: emerge --changed-use --oneshot app-portage/gentoolkit
+      changed_when: false
+# The rest of the original file is specific to that role and not needed here

--- a/molecule/gentoo/verify.yml
+++ b/molecule/gentoo/verify.yml
@@ -1,0 +1,92 @@
+---
+# This is an example playbook to execute Ansible tests.
+
+- name: Verify
+  hosts: all
+  gather_facts: false
+  tasks:
+
+  - name: check for nftables.d
+    stat:
+      path: /etc/nftables.d
+    register: p
+
+  - name: check nftables.d
+    assert:
+      that:
+        - p.stat.exists and p.stat.isdir
+
+  - name: check for nftables.conf
+    stat:
+      path: /etc/nftables.conf
+    register: p
+
+  - name: check nftables.conf
+    assert:
+      that:
+        - p.stat.exists
+
+  - name: check for filter-input.nft
+    stat:
+      path: /etc/nftables.d/filter-input.nft
+    register: p
+
+  - name: check filter-input.nft
+    assert:
+      that:
+        - p.stat.exists
+
+  - name: list rules
+    command: nft list ruleset
+    register: nft
+
+  - name: debug rules
+    debug: var=nft
+
+  - name: check rules
+    assert:
+      that:
+        # The whole line is:
+        # type filter hook input priority 0; policy drop;
+        # However on CentOS will return "priority 0", while Debian will
+        # show "priority filter"
+        - '"type filter hook input" in nft.stdout'
+        - '"type filter hook output" in nft.stdout'
+
+  - name: check for fail2ban systemd custom dir
+    stat:
+      path: /etc/systemd/system/fail2ban.service.d
+    register: f2b_systemd_dir
+
+  - name: check fail2ban systemd custom dir
+    assert:
+      that:
+        - f2b_systemd_dir.stat.exists and f2b_systemd_dir.stat.isdir
+
+  - name: check for fail2ban systemd override
+    stat:
+      path: /etc/systemd/system/fail2ban.service.d/override.conf
+    register: f2b_systemd_override
+
+  - name: check fail2ban systemd override
+    assert:
+      that:
+        - f2b_systemd_override.stat.exists
+
+  - name: service status - active
+    command: systemctl is-active nftables.service
+    register: status
+
+  - name: check service status
+    assert:
+      that:
+        - 'status.stdout == "active"'
+
+  - name: service status - enabled
+    command: systemctl is-enabled nftables.service
+    register: status
+
+  - name: check service status
+    assert:
+      that:
+        - 'status.stdout == "enabled"'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -59,7 +59,7 @@
   package:
     name: '{{ nft_pkg_list | list }}'
     state: '{{ nft_pkg_state }}'
-    update_cache: true
+    # update_cache: true
   register: pkg_install_result
   until: pkg_install_result is success
   when: nft_enabled|bool


### PR DESCRIPTION
This commit adds molecule tests for Gentoo.

Since the tests run inside docker and on systemd system, the host system
also needs to run systemd.

The tests create volumes in /srv/ so that artifacts that take a long
time to build and synchronize are reused between test runs.

This specific commit also fixes the error in ipr-cnrs/nftables#24