### PR TITLE
[WIP] Added netdev table rule management

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,14 @@ complexify his philosophy… (I'm pretty sure, i now did complexify it :D) ^^
 * **nft_merged_groups** : If variables from the hosts Ansible groups should be merged [default : `false`].
 * **nft_merged_groups_dir** : The dictionary where the nftables group rules, named like the Ansible groups, are located in [default : `vars/`].
 * **nft_debug** : Toggle more verbose output on/off. [default: 'false'].
+* **nft__netdev_table_manage**: If the `netdev` table should be managed. Sets up a chain for controlling `ingress` that can catch packets before they are passed further. [default: `false`]
+    + **nft__netdev_device_name**: the ingress hook is attached to a particular network interface. **Important**: Please specify the interface name for the ingress chain to work.
+    + **nft__netdev_default_ingress_rules**: Set default rules for `ingress` chain of **netdev** table.
+    + **nft__netdev_ingress_rules** : Set rules for `ingress` chain of **netdev** table for all hosts in the Ansible inventory.
+    + **nft__netdev_group_ingress_rules** : Set rules for `ingress` chain of **netdev** table for hosts in specific Ansible inventory group.
+    + **nft__netdev_host_ingress_rules** : Set rules for `ingress` chain of **netdev** table for specific hosts the Ansible inventory.
+    + **nft__netdev_ingress_conf_path** : ingress configuration file include in the main configuration [default : `{{ nft_conf_dir_path }}/netdev-ingress.nft`].
+    + **nft__netdev_ingress_conf_content** : Template used to generate the previous ingress configuration file [default : `etc/nftables.d/netdev-ingress.nft.j2`].
 
 ### OS Specific Variables
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -511,6 +511,60 @@ nft__nat_postrouting_conf_path: '{{ nft_conf_dir_path }}/nat-postrouting.nft'
 nft__nat_postrouting_conf_content: 'etc/nftables.d/nat-postrouting.nft.j2'
                                                                    # ]]]
                                                                    # ]]]
+
+# .. envvar:: nft__netdev_table_manage [[[
+#
+# If the netdev table should be managed ? Possible options are :
+#
+# ``False``
+#   Default. The netdev table is not managed and rules will not be added.
+#
+# ``True``
+#   Add the ingress rules that follow.
+nft__netdev_table_manage: False
+                                                                   # ]]]
+# .. envvar:: nft__netdev_default_ingress_rules [[[
+#
+# List of ingress rules to configure for all hosts inherited from this role.
+# Note: unlike other tables, ingress hooks need a device name to be operational
+#
+nft__netdev_default_ingress_rules:
+  000 policy:
+    - type filter hook ingress device {{ nft__netdev_device_name }} priority -500;
+                                                                   # ]]]
+# .. envvar:: nft__netdev_ingress_rules [[[
+#
+# List of prerouting rules to configure for all hosts in the Ansible inventory.
+nft__netdev_ingress_rules: {}
+                                                                   # ]]]
+# .. envvar:: nft__netdev_group_ingress_rules [[[
+#
+# List of ingress rules to configure for hosts in specific
+# Ansible inventory group.
+nft__netdev_group_ingress_rules: {}
+                                                                   # ]]]
+# .. envvar:: nft__netdev_host_ingress_rules [[[
+#
+# List of ingress rules to configure for specific hosts
+# in the Ansible inventory.
+nft__netdev_host_ingress_rules: {}
+                                                                   # ]]]
+# .. envvar:: nft__netdev_ingress_conf_path [[[
+#
+# Path to the ingress rules file for the netdev table to include in the main
+# configuration file in order to use the previous defined lists.
+#
+# Should include the '{{ nft_conf_dir_path }}' var or be an absolut path.
+nft__netdev_ingress_conf_path: '{{ nft_conf_dir_path }}/netdev-ingress.nft'
+                                                                   # ]]]
+# .. envvar:: nft__netdev_ingress_conf_content [[[
+#
+# Template used to provide the previous ingress rules file.
+#
+# Must be a relative path from default/ directory of this role or from your
+# Ansible inventory directory.
+nft__netdev_ingress_conf_content: 'etc/nftables.d/netdev-ingress.nft.j2'
+                                                                   # ]]]
 # Service management [[[
 # ----------------------
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -179,6 +179,25 @@
   when: (nft_enabled|bool and
          nft__nat_table_manage|bool)
 
+# Netdev table content [[[1
+- name: Manage netdev table
+  block:
+  - name: Check that the nft__netdev_device_name is set
+    debug:
+      msg: "if net__netdev_table_manage is set - nft__netdev_device_name must be set to an interface name"
+    failed_when: nft__netdev_device_name is not defined
+  - name: Netdev table - generate ingress rules file
+    template:
+      src: "{{ nft__netdev_ingress_conf_content }}"
+      dest: "{{ nft__netdev_ingress_conf_path }}"
+      owner: root
+      group: root
+      mode: 0755
+      backup: "{{ nft_backup_conf }}"
+    notify: ['Reload nftables service']
+  when: (nft_enabled|bool and
+         nft__netdev_table_manage|bool)
+
 # Manage nftables service [[[1
 - name: Install nftables Debian systemd service unit
   template:

--- a/templates/etc/nftables.conf.j2
+++ b/templates/etc/nftables.conf.j2
@@ -52,6 +52,12 @@ table ip nat {
 }
 {% endif %}
 
+{% if nft__netdev_table_manage %}
+table netdev filter {
+	include "{{ nft__netdev_ingress_conf_path }}"
+}
+{% endif %}
+
 {% if nft__custom_content|d() %}
 # Custom content from ipr-cnrs.nftables
 {{ nft__custom_content }}

--- a/templates/etc/nftables.d/netdev-ingress.nft.j2
+++ b/templates/etc/nftables.d/netdev-ingress.nft.j2
@@ -1,0 +1,21 @@
+#jinja2: lstrip_blocks: "True", trim_blocks: "True"
+# {{ ansible_managed }}
+{% set ingressmerged = nft__netdev_default_ingress_rules.copy() %}
+{% set _ = ingressmerged.update(nft__netdev_ingress_rules) %}
+{% set _ = ingressmerged.update(nft__netdev_group_ingress_rules) %}
+{% if nft_merged_groups and hostvars[inventory_hostname]['nft_combined_rules'].nft__netdev_group_ingress_rules is defined %}
+  {% set _ = ingressmerged.update(hostvars[inventory_hostname]['nft_combined_rules'].nft__netdev_group_ingress_rules) %}
+{% endif %}
+{% set _ = ingressmerged.update(nft__netdev_host_ingress_rules) %}
+
+chain ingress {
+{% for group, rules in ingressmerged|dictsort  %}
+	# {{ group }}
+  {% if not rules %}
+	# (none)
+  {% endif %}
+  {% for rule in rules %}
+	{{ rule }}
+  {% endfor %}
+{% endfor %}
+}


### PR DESCRIPTION
Inspired by [this](https://blog.samuel.domains/blog/security/nftables-hardening-rules-and-good-practices) post, this commit adds support for managing ingress chain in netdev table.

It could be used to catch DDoS attacks and weird packets before they reach other chains.

According to [this](https://wiki.nftables.org/wiki-nftables/index.php/Netfilter_hooks) article, ingress hook requires a particular network interface to be specified, so I added an extra variable(`nft__netdev_device_name`) to hold the name of the interface.

Example configuration:

```yaml
  vars:
    - nft__netdev_table_manage: true
    - nft__netdev_device_name: "eth0"
    - nft__netdev_ingress_rules:
        100 kill fragments:
          - ip frag-off & 0x1fff != 0 counter drop
        105 TCP XMAS:
          - tcp flags & (fin|syn|rst|psh|ack|urg) == fin|syn|rst|psh|ack|urg counter drop
        110 TCP NULL:
          - tcp flags & (fin|syn|rst|psh|ack|urg) == 0x0 counter drop
```

results in:

```
# nft list table netdev filter
table netdev filter {
        chain ingress {
                type filter hook ingress device "eth0" priority -500; policy accept;
                ip frag-off & 8191 != 0 counter packets 0 bytes 0 drop
                tcp flags & (fin | syn | rst | psh | ack | urg) == fin | syn | rst | psh | ack | urg counter packets 0 bytes 0 drop
                tcp flags & (fin | syn | rst | psh | ack | urg) == 0x0 counter packets 0 bytes 0 drop
        }
}
```

Currently this is in state "works for me", will need to monitor for some time

To be done:

* Test that the new rules did not break anything in molecule