### PR TITLE
ansible_managed into 'comment' jinja filter to handle multi-line ansi…

### DIFF
--- a/templates/etc/nftables.conf.j2
+++ b/templates/etc/nftables.conf.j2
@@ -1,6 +1,6 @@
 #jinja2: lstrip_blocks: "True", trim_blocks: "True"
 #!{{ nft__bin_location }} -f
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 {% set globalmerged = nft_global_default_rules.copy() %}
 {% set _ = globalmerged.update(nft_global_rules) %}
 {% set _ = globalmerged.update(nft_global_group_rules) %}

--- a/templates/etc/nftables.d/defines.nft.j2
+++ b/templates/etc/nftables.d/defines.nft.j2
@@ -1,5 +1,5 @@
 #jinja2: lstrip_blocks: "True", trim_blocks: "True"
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 {% set definemerged = nft_define_default.copy() %}
 {% set _ = definemerged.update(nft_define) %}
 {% set _ = definemerged.update(nft_define_group) %}

--- a/templates/etc/nftables.d/filter-forward.nft.j2
+++ b/templates/etc/nftables.d/filter-forward.nft.j2
@@ -1,5 +1,5 @@
 #jinja2: lstrip_blocks: "True", trim_blocks: "True"
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 {% set forwardmerged = nft_forward_default_rules.copy() %}
 {% set _ = forwardmerged.update(nft_forward_rules) %}
 {% set _ = forwardmerged.update(nft_forward_group_rules) %}

--- a/templates/etc/nftables.d/filter-input.nft.j2
+++ b/templates/etc/nftables.d/filter-input.nft.j2
@@ -1,5 +1,5 @@
 #jinja2: lstrip_blocks: "True", trim_blocks: "True"
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 {% set inputmerged = nft_input_default_rules.copy() %}
 {% set _ = inputmerged.update(nft_input_rules) %}
 {% set _ = inputmerged.update(nft_input_group_rules) %}

--- a/templates/etc/nftables.d/filter-output.nft.j2
+++ b/templates/etc/nftables.d/filter-output.nft.j2
@@ -1,5 +1,5 @@
 #jinja2: lstrip_blocks: "True", trim_blocks: "True"
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 {% set outputmerged = nft_output_default_rules.copy() %}
 {% set _ = outputmerged.update(nft_output_rules) %}
 {% set _ = outputmerged.update(nft_output_group_rules) %}

--- a/templates/etc/nftables.d/nat-postrouting.nft.j2
+++ b/templates/etc/nftables.d/nat-postrouting.nft.j2
@@ -1,5 +1,5 @@
 #jinja2: lstrip_blocks: "True", trim_blocks: "True"
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 {% set postroutingmerged = nft__nat_default_postrouting_rules.copy() %}
 {% set _ = postroutingmerged.update(nft__nat_postrouting_rules) %}
 {% set _ = postroutingmerged.update(nft__nat_group_postrouting_rules) %}

--- a/templates/etc/nftables.d/nat-prerouting.nft.j2
+++ b/templates/etc/nftables.d/nat-prerouting.nft.j2
@@ -1,5 +1,5 @@
 #jinja2: lstrip_blocks: "True", trim_blocks: "True"
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 {% set preroutingmerged = nft__nat_default_prerouting_rules.copy() %}
 {% set _ = preroutingmerged.update(nft__nat_prerouting_rules) %}
 {% set _ = preroutingmerged.update(nft__nat_group_prerouting_rules) %}

--- a/templates/etc/nftables.d/sets.nft.j2
+++ b/templates/etc/nftables.d/sets.nft.j2
@@ -1,5 +1,5 @@
 #jinja2: lstrip_blocks: "True", trim_blocks: "True"
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 {% set setmerged = nft_set_default.copy() %}
 {% set _ = setmerged.update(nft_set) %}
 {% set _ = setmerged.update(nft_set_group) %}

--- a/templates/etc/systemd/system/fail2ban.service.d/override.conf.j2
+++ b/templates/etc/systemd/system/fail2ban.service.d/override.conf.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 
 [Unit]
 After=network.target iptables.service firewalld.service ip6tables.service ipset.service nftables.service

--- a/templates/etc/systemd/system/nftables.service.d/override.conf.j2
+++ b/templates/etc/systemd/system/nftables.service.d/override.conf.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 
 [Service]
 {% if not nft__service_protect %}

--- a/templates/lib/systemd/system/nftables.service.j2
+++ b/templates/lib/systemd/system/nftables.service.j2
@@ -1,4 +1,4 @@
-# {{ ansible_managed }}
+{{ ansible_managed | comment }}
 [Unit]
 Description={{ nft_service_name }}
 Documentation=man:nft(8) http://wiki.nftables.org


### PR DESCRIPTION
The ansible_managed string may be multi-line which currently causes an invalid nftables configuration to be generated. The ansible_managed string should be piped into the `comment` jinja2 filter so that multi-line blocks are commented on all lines.