### PR TITLE
optionnaly disable preexisting firewalls

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,7 @@ complexify his philosophy… (I'm pretty sure, i now did complexify it :D) ^^
 * **nft_merged_groups** : If variables from the hosts Ansible groups should be merged [default : `false`].
 * **nft_merged_groups_dir** : The dictionary where the nftables group rules, named like the Ansible groups, are located in [default : `vars/`].
 * **nft_debug** : Toggle more verbose output on/off. [default: 'false'].
+* **nft_disable_preinstalled_firewalls** : Shall we disable preexisting firewalls to avoid conflicts? [default : `true`].
 
 ### OS Specific Variables
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -607,6 +607,17 @@ nft_debug: False
 #   Configs will not be backuped.
 nft_backup_conf: True
                                                                    # ]]]
+# .. envvar:: nft_disable_preinstalled_firewalls [[[
+#
+# Shall we disable preexisting firewalls to avoid conflicts? Possible options are :
+#
+# ``True``
+#   Default. The conflicting service will be disabled.
+#
+# ``False``
+#   The conflicting services will be leaved as is.
+nft_disable_preinstalled_firewalls: true
+                                                                   # ]]]
                                                                    # ]]]
                                                                    # ]]]
 # OS specific variables defaults [[[

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -248,3 +248,22 @@
     - nft_enabled|bool
     - nft_service_manage|bool
   notify: ['Restart nftables service']
+
+
+# Disable preinstalled firewalls [[[1
+- name: check if firewalld is installed
+  package_facts:
+    manager: "auto"
+  when:
+    - ansible_os_family == "RedHat"
+    - nft_disable_preinstalled_firewalls
+
+- name: disable firewalld
+  service:
+    name: firewalld
+    state: stopped
+    enabled: false
+  when:
+    - ansible_os_family == "RedHat"
+    - "'firewalld' in ansible_facts.packages"
+    - nft_disable_preinstalled_firewalls


### PR DESCRIPTION
When firewalld is found on the machine, it's probably best to disable it to prevent it messing up with nftables.