### PR TITLE
Tell Linguist to treat .yml as code

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Linguist: treat YAML as code
+*.yml linguist-detectable=true


### PR DESCRIPTION
Makes YAML detectable as code instead of data for the Lingiust language detection. Which in turn generates statistics and the language bar on GitHub and GitLab (and maybe more).