### PR TITLE
Allow skipping of Fail2ban integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,10 +574,11 @@ This role will :
 
 Before Debian Bullseye, systemd unit for Fail2ban doesn't come with a decent
 integration with Nftables.
-So this role will create override file for `fail2ban` unit, even if it's not
-(yet) available on the host, in order to :
-* Start `fail2ban` unit after `nftables`.
-* Restart `fail2ban` unit when `nftables` unit restart.
+This role will create override file for `fail2ban` unit, unless
+`nft_fail2ban_service_override` is set to `false`. Default is to add it even if
+it's not (yet) available on the host. This ensures :
+* The `fail2ban` unit is started after the `nftables` unit.
+* The `fail2ban` unit is restarted when `nftables` unit restarts.
 
 ## Development
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -573,6 +573,18 @@ nft__service_override_content: 'etc/systemd/system/nftables.service.d/override.c
 nft__service_protect: true
                                                                    # ]]]
 
+# .. envvar:: nft_fail2ban_service_override [[[
+#
+# Should the systemd unit override file for fail2ban.service be added?
+
+# Options:
+# ``True``:
+#   Default. The fail2ban override file should be present, at path 'nft__fail2ban_service_unit_path'.
+#
+# ``False``:
+#   Skip the tasks that put the fail2ban override file into place.
+nft_fail2ban_service_override: true
+                                                                   # ]]]
 # .. envvar:: nft__fail2ban_service_unit_path [[[
 #
 # Path to store Fail2Ban custom conf.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -234,6 +234,7 @@
     mode: '0755'
   when:
     - nft_enabled|bool
+    - nft_fail2ban_service_override|bool
     - nft_service_manage|bool
 
 - name: Install Debian Fail2Ban custom service
@@ -246,5 +247,6 @@
   register: nftables__register_fail2ban_service
   when:
     - nft_enabled|bool
+    - nft_fail2ban_service_override|bool
     - nft_service_manage|bool
   notify: ['Restart nftables service']


### PR DESCRIPTION
Boolean nft_fail2ban_service_override allows the user to skip fail2ban
related tasks. For those who do not use fail2ban and prefer not to add
unused file(s) on their system(s).

Variable nft_fail2ban_service_override defaults to 'true'.
Ensuring behaviour out of the box remains the same as before.