### PR TITLE
Add RedHat flavoring

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -541,6 +541,18 @@ nft_service_name: 'nftables'
 #   The service is disabled from startup.
 nft_service_enabled: true
                                                                    # ]]]
+# .. envvar:: nft_service_unit_from_role [[[
+#
+# Should the role supply a custom nftables.service unit file?
+# Or use the distribution provided one?
+#
+# ``true``
+#   Default. Install our service unit, written to 'nft_service_unit_path'.
+#
+# ``false``
+#   No service unit will be added. Use distribution provided nftables.service.
+nft_service_unit_from_role: true
+                                                                   # ]]]
 # .. envvar:: nft_service_unit_path [[[
 #
 # Path to store Nftables service.

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -7,3 +7,6 @@
       nft_debug: true
       # can't remove iptables on an instance with docker
       nft_old_pkg_manage: false
+      # Prevent distribution-specific paths while testing
+      nft_conf_dir_path: '/etc/nftables.d'
+      nft_main_conf_path: '/etc/nftables.conf'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -79,11 +79,11 @@
          nft_old_pkg_manage|bool)
 
 # Common configuration [[[1
-- name: Ensure to create nftables.d directory
+- name: Ensure the nftables config directory
   file:
     path: "{{ nft_conf_dir_path }}"
     state: directory
-    mode: 0755
+    mode: 0700
   when: nft_enabled|bool
 
 - name: CONFIG generate main conf file
@@ -92,7 +92,7 @@
     dest: "{{ nft_main_conf_path }}"
     owner: root
     group: root
-    mode: 0755
+    mode: 0700
     backup: "{{ nft_backup_conf }}"
   notify: ['Reload nftables service']
   when: nft_enabled|bool
@@ -103,7 +103,7 @@
     dest: "{{ nft_define_conf_path }}"
     owner: root
     group: root
-    mode: 0755
+    mode: 0600
     backup: "{{ nft_backup_conf }}"
   notify: ['Reload nftables service']
   when: nft_enabled|bool
@@ -114,7 +114,7 @@
     dest: "{{ nft_set_conf_path }}"
     owner: root
     group: root
-    mode: 0755
+    mode: 0600
     backup: "{{ nft_backup_conf }}"
   notify: ['Reload nftables service']
   when: nft_enabled|bool
@@ -126,7 +126,7 @@
     dest: "{{ nft_input_conf_path }}"
     owner: root
     group: root
-    mode: 0755
+    mode: 0600
     backup: "{{ nft_backup_conf }}"
   notify: ['Reload nftables service']
   when: nft_enabled|bool
@@ -137,7 +137,7 @@
     dest: "{{ nft_output_conf_path }}"
     owner: root
     group: root
-    mode: 0755
+    mode: 0600
     backup: "{{ nft_backup_conf }}"
   notify: ['Reload nftables service']
   when: nft_enabled|bool
@@ -148,7 +148,7 @@
     dest: "{{ nft_forward_conf_path }}"
     owner: root
     group: root
-    mode: 0755
+    mode: 0600
     backup: yes
   notify: ['Reload nftables service']
   when: (nft_enabled|bool and
@@ -161,7 +161,7 @@
     dest: "{{ nft__nat_prerouting_conf_path }}"
     owner: root
     group: root
-    mode: 0755
+    mode: 0600
     backup: "{{ nft_backup_conf }}"
   notify: ['Reload nftables service']
   when: (nft_enabled|bool and
@@ -173,7 +173,7 @@
     dest: "{{ nft__nat_postrouting_conf_path }}"
     owner: root
     group: root
-    mode: 0755
+    mode: 0600
     backup: "{{ nft_backup_conf }}"
   notify: ['Reload nftables service']
   when: (nft_enabled|bool and

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -180,7 +180,7 @@
          nft__nat_table_manage|bool)
 
 # Manage nftables service [[[1
-- name: Install nftables Debian systemd service unit
+- name: Install managed nftables systemd service unit
   template:
     src: '{{ nft_service_unit_content }}'
     dest: '{{ nft_service_unit_path }}'
@@ -188,8 +188,10 @@
     group: 'root'
     mode: '0644'
   register: nftables__register_systemd_service
-  when: (nft_enabled|bool and
-         nft_service_manage|bool)
+  when:
+    - nft_enabled|bool
+    - nft_service_manage|bool
+    - nft_service_unit_from_role|bool
   notify: ['Restart nftables service']
 
 - name: Ensure to remove nftables systemd service from old target
@@ -197,8 +199,10 @@
     path: '/etc/systemd/system/multi-user.target.wants/nftables.service'
     state: absent
   register: nftables__register_fix_systemd_target
-  when: (nft_enabled|bool and
-         nft_service_manage|bool)
+  when:
+    - nft_enabled|bool
+    - nft_service_manage|bool
+    - nft_service_unit_from_role|bool
   notify: ['Restart nftables service']
 
 # Manage custom nftables service [[[1

--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -1,4 +1,8 @@
 ---
-# vars file for Centos-based distros
+# vars file for RedHat-based distros
 nft_pkg_list:
   - nftables
+
+# Use Red Hat flavored paths for main config and included file(s) location:
+nft_main_conf_path: '/etc/sysconfig/nftables.conf'
+nft_conf_dir_path: '/etc/nftables'


### PR DESCRIPTION
PR to resolve most of the mentioned differences in issue #39 

What changes did I make:

1. https://github.com/ipr-cnrs/nftables/pull/42/commits/7430b9e9b0e6b28d7430bdea39d4994e67a5169d Configure the role to use Red Hat default paths/locations when run against Red Hat systems. This helps admins find files where they would expect them.
2. https://github.com/ipr-cnrs/nftables/commit/f24cffa5d607236817e36ef84ea2f29160999c05 Applies more strict permissions to nftables configuration files. Preventing non-root users from being able to view the firewall configuration.
3. https://github.com/ipr-cnrs/nftables/commit/b45b343f3464d68dc15b1b6b892d6a2a026efe5f Add a toggle so a user can decide to use the role managed systemd unit file or use the distribution provided one. Defaults to the role managed variant, keeping the same behaviour as before this change.

Only the first commit is strictly Red Hat flavoring. The third allows the user to stick with the Red Hat provided service file. And passing a security audit is probably easier with commit 2 and 3 in place.