### PR TITLE
Ability to create custom chains

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,8 @@ complexify his philosophy… (I'm pretty sure, i now did complexify it :D) ^^
 * **nft_output_conf_content** : Template used to generate the previous output configuration file [default : `etc/nftables.d/filter-output.nft.j2`].
 * **nft_forward_conf_path** : forward configuration file include in main configuration file [default : `{{ nft_conf_dir_path }}/filter-forward.nft`].
 * **nft_forward_conf_content** : Template used to generate the previous forward configuration file [default : `etc/nftables.d/filter-forward.nft.j2`].
+* **nft_custom_conf_path** : Custom chains configuration file include in main configuration file [default : `{{ nft_conf_dir_path }}/filter-custom.nft`].
+* **nft_custom_conf_content** : Template used to generate custom chains configuration file [default : `etc/nftables.d/filter-custom.nft.j2`].
 * **nft_define_conf_path** : Vars definition file include in main configuration file [default : `{{ nft_conf_dir_path }}/defines.nft`].
 * **nft_define_conf_content** : Template used to generate the previous vars definition file [default : `etc/nftables.d/defines.nft.j2`].
 * **nft_sets_conf_path** : Sets and maps definition file include in main configuration file [default : `{{ nft_conf_dir_path }}/sets.nft`].
@@ -46,6 +48,7 @@ complexify his philosophy… (I'm pretty sure, i now did complexify it :D) ^^
 * **nft_global_group_rules** : You can add `global` rules or override those defined by **nft_global_default_rules** and **nft_global_rules** for a group.
 * **nft_global_host_rules** : Hosts can also add or override all previours rules.
 * **nft__custom_content** : Custom content (tables, include,…) to add in Nftables configuration [default : `''`].
+* **nft_define_custom_chains** : Custom chains. Mapping of lists, where key is chain name, and list values are variables names with rules.
 * **nft_input_default_rules** : Set default rules for `input` chain.
 * **nft_input_rules** : You can add `input` rules or override those defined by **nft_input_default_rules** for all hosts.
 * **nft_input_group_rules** : You can add `input` rules or override those defined by **nft_input_default_rules** and **nft_input_rules** for a group.
@@ -556,6 +559,69 @@ nft_input_group_rules:
 1. These rulesets, from the two groups, will be merged if the host is a member
    of these groups.
 </details>
+
+### With custom chains
+
+<details>
+  <summary>Define custom chain for usage with docker (<i>click to expand</i>)</summary>
+
+Group vars (e.g. `docker_server.yml`)
+
+```yaml
+nft_old_pkg_manage: false
+nft__forward_table_manage: true
+
+# specify chains and which variables contains rules that should be used for building chain rule set
+nft_define_custom_chains:
+  docker:
+    - nft_docker_group_rules
+    - nft_docker_tenant_rules
+    - nft_docker_host_rules
+
+nft_docker_group_rules:
+  '100 allow internal vpn':
+    - 'ip saddr 10.254.0.0/16 counter accept'
+    - 'ip6 saddr 2001:db8:deaf:beaf::/64 counter accept'
+
+nft_docker_tenant_rules:
+  '200 allow ssh connection for tenant vpn':
+    - 'ip saddr 198.51.100.18 tcp dport { 22 } counter accept'
+
+nft_docker_host_rules: {}
+
+nft_forward_default_rules:
+  '000 policy':
+    - 'type filter hook forward priority -200; policy drop;'
+  '005 global':
+    - 'jump global'
+
+nft_forward_group_rules:
+  '050 docker - allow connection from containers to internet':
+    - 'iifname "docker0" counter accept'
+  '099 jump docker':
+    - 'jump docker'
+
+nft_input_group_rules:
+  '099 jump docker':
+    - 'jump docker'
+
+```
+
+Playbook and host vars
+
+``` yaml
+- hosts: docker_server
+  vars:
+    nft_docker_host_rules:
+      '300 allow http/s':
+        - 'tcp dport { 80, 443 } counter accept'
+
+  roles:
+    - role: ipr-cnrs.nftables
+```
+
+</details>
+
 
 ## Configuration
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -309,6 +309,16 @@ nft_input_conf_path: '{{ nft_conf_dir_path }}/filter-input.nft'
 nft_input_conf_content: 'etc/nftables.d/filter-input.nft.j2'
                                                                    # ]]]
 
+nft_custom_conf_path: '{{ nft_conf_dir_path }}/filter-custom.nft'
+nft_custom_conf_content: 'etc/nftables.d/filter-custom.nft.j2'
+
+nft_define_custom_chains: {}
+#  docker:
+#    - nft_docker_rules
+#    - nft_docker_group_rules
+#    - nft_docker_host_rules
+
+
 # .. envvar:: nft_output_default_rules [[[
 #
 # List of output rules to configure for all hosts inherited from this role.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -154,6 +154,18 @@
   when: (nft_enabled|bool and
          nft__forward_table_manage|bool)
 
+- name: Filter table - generate custom rules file
+  template:
+    src: "{{ nft_custom_conf_content }}"
+    dest: "{{ nft_custom_conf_path }}"
+    owner: root
+    group: root
+    mode: 0755
+    backup: yes
+  notify: ['Reload nftables service']
+  when: (nft_enabled|bool and
+         nft_define_custom_chains.keys()|length > 0)
+
 # Nat table content [[[1
 - name: Nat table - generate prerouting rules file
   template:

--- a/templates/etc/nftables.conf.j2
+++ b/templates/etc/nftables.conf.j2
@@ -32,6 +32,9 @@ table inet filter {
 {% if nft__forward_table_manage %}
 	include "{{ nft_forward_conf_path }}"
 {% endif %}
+{% if nft_define_custom_chains %}
+	include "{{ nft_custom_conf_path }}"
+{% endif %}
 {% if nft_custom_includes | default() %}
   {% if nft_custom_includes is string %}
 	include "{{ nft_custom_includes }}"

--- a/templates/etc/nftables.d/filter-custom.nft.j2
+++ b/templates/etc/nftables.d/filter-custom.nft.j2
@@ -1,0 +1,21 @@
+#jinja2: lstrip_blocks: "True", trim_blocks: "True"
+# {{ ansible_managed }}
+
+{% for chain,sections in nft_define_custom_chains.items() %}
+  {% set custommerged = hostvars[inventory_hostname][sections[0]].copy() %}
+  {% for section in sections[1:] %}
+    {% set _ = custommerged.update(hostvars[inventory_hostname][section].copy()) %}
+  {% endfor %}
+
+chain {{ chain }} {
+{% for group, rules in custommerged|dictsort  %}
+  # {{ group }}
+  {% if not rules %}
+  # (none)
+  {% endif %}
+  {% for rule in rules %}
+  {{ rule }}
+  {% endfor %}
+{% endfor %}
+}
+{% endfor %}


### PR DESCRIPTION
Hi. First of all, thank you for this awesome role!

Proposed feature allows creation of custom chains, in similar way how `nft_input_rules` / `nft_input_group_rules` / `nft_input_host_rules` works.

Example usage:

1. If you have IPv4 / IPv6 dualstack on docker server, you need to define all rules duplicitly in `input` and `forward` chains. With custom chain you can create for example `docker` chain and use `jump docker` in both `input` and `forward`.
2. If three levels (default / group / host) is not enough.