### PR TITLE
Do not remove `iptables` on Arch Linux

### DIFF
--- a/vars/archlinux.yml
+++ b/vars/archlinux.yml
@@ -2,3 +2,5 @@
 # vars file for Archlinux-based distros
 nft_pkg_list:
   - nftables
+# iptables cannot be removed on Arch
+nft_old_pkg_manage: false


### PR DESCRIPTION
`iptables` package cannot be removed on Arch Linux, can be only replaced by `iptables-nft`

Solves https://github.com/ipr-cnrs/nftables/issues/43