### PR TITLE
Fix non-functioning check mode

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -179,7 +179,7 @@
   when: (nft_enabled|bool and
          nft__nat_table_manage|bool)
 
-# Manage nftables service [[[1
+# Manage nftables service units [[[1
 - name: Install managed nftables systemd service unit
   template:
     src: '{{ nft_service_unit_content }}'
@@ -253,7 +253,8 @@
     - nft_service_manage|bool
   notify: ['Restart nftables service']
 
-- name: Enable nftables service
+# Manage nftables service [[[1
+- name: Manage nftables service
   systemd:
     state: 'started'
     name: '{{ nft_service_name }}'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -260,4 +260,7 @@
     enabled: '{{ nft_service_enabled }}'
   async: 5
   poll: 2
-  when: ansible_service_mgr == 'systemd' and nft_service_manage
+  when:
+    - not ansible_check_mode
+    - ansible_service_mgr == 'systemd'
+    - nft_service_manage

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -259,7 +259,7 @@
     state: 'started'
     name: '{{ nft_service_name }}'
     enabled: '{{ nft_service_enabled }}'
-  async: 5
+  async: 10
   poll: 2
   when:
     - not ansible_check_mode


### PR DESCRIPTION
When running `ansible-playbook` in check mode (`--check`) task `Enable nftables service` would fail:

```
An exception occurred during task execution. To see the full traceback, use -vvv. The error was: NoneType: None
fatal: [<hostname>]: FAILED! => changed=false 
  msg: check mode and async cannot be used on same task.
```

This change adds a condition to execute this task when not running in check mode only.

I also extended the `async` timeout a bit to ensure a slower system would not time out. A async value of `10` is a multiple of `2` (the `poll` value). The polling frequency now fits nicely within the `async` timeout.

And I added a (Vim) editor fold for the last task and renamed the task name to match the fold name.