### PR TITLE
:bug: fix: output ICMP default rule

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -320,8 +320,7 @@ nft_output_default_rules:
   015 localhost:
     - oif lo accept
   050 icmp:
-    - ip protocol icmp accept
-    - ip6 nexthdr icmpv6 counter accept
+    - meta l4proto {icmp,icmpv6} counter accept
   200 output udp accepted:
     - udp dport @out_udp_accept ct state new accept
   210 output tcp accepted:


### PR DESCRIPTION
Ref: https://superuser.com/a/1748406/160408

> Note: ICMPv6 in the output chain should be handled like it was in the input chain. Instead of:
>
>    ip protocol icmp accept # handle 24
>    ip6 nexthdr ipv6-icmp counter packets 3 bytes 192 accept # handle 25
>
>this should be used:
>
>meta l4proto { icmp, ipv6-icmp } counter accept
>
>The reason, [as documented](https://manpages.debian.org/nftables/nft.8#IPV6_HEADER_EXPRESSION), is that one should almost never use ip6 nexthdr which isn't the exact equivalent of ip protocol: it might match an intermediate header rather than the final ICMPv6 header, and thus fail to allow traffic.