### PR TITLE
Async does not support check_mode

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -12,7 +12,10 @@
     name: '{{ nft_service_name }}'
   async: 5
   poll: 2
-  when: ansible_service_mgr == 'systemd' and nft_service_manage
+  when:
+    - not ansible_check_mode
+    - ansible_service_mgr == 'systemd'
+    - nft_service_manage
 
 # Reload will avoid to loose Nftables rulebase if an invalid syntax is added
 - name: Reload nftables service
@@ -21,6 +24,8 @@
     name: '{{ nft_service_name }}'
   async: 5
   poll: 2
-  when: ansible_service_mgr == 'systemd' and
-        nft_service_manage and
-        not nftables__register_systemd_service.changed
+  when:
+    - not ansible_check_mode
+    - ansible_service_mgr == 'systemd'
+    - nft_service_manage
+    - not nftables__register_systemd_service.changed


### PR DESCRIPTION
From https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_async.html
> As of Ansible 2.3, async does not support check mode and will fail the task when run in check mode. See [Validating tasks: check mode and diff mode](https://docs.ansible.com/ansible/latest/playbook_guide/playbooks_checkmode.html#id3) on how to skip a task in check mode.

Checking for ansible_check_mode will prevent getting an error when running in check mode.

Also, when you have multiple conditions that all need to be true (that is, a logical "and"), you can specify them as a list.