### PR TITLE
Use `inet` table for NAT

### DIFF
--- a/templates/etc/nftables.conf.j2
+++ b/templates/etc/nftables.conf.j2
@@ -45,7 +45,7 @@ table inet filter {
 
 {% if nft__nat_table_manage %}
 # Additionnal table for Network Address Translation (NAT)
-table ip nat {
+table inet nat {
 	include "{{ nft_set_conf_path }}"
 	include "{{ nft__nat_prerouting_conf_path }}"
 	include "{{ nft__nat_postrouting_conf_path }}"


### PR DESCRIPTION
Backport the change from PR#16 to use `table inet` for NAT rules which allows to use IPv4 and IPv6 NAT. That PR was quite complex, so I just took this one change https://github.com/ipr-cnrs/nftables/pull/16/files#diff-0ba04fe495b3a23c822f5d5113cbe2337c80e145357139428373f395d3578472L48