### PR TITLE
templates: fix icmpv6 redirects rules

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -789,13 +789,13 @@ nft_templates:
 
     # RFC 4890, 4.4.4.  Traffic for Which a Policy Should Be Defined
 
-    - meta l4proto ipv6-icmp icmpv6 type nd-redirect ip6 counter accept
+    - meta l4proto ipv6-icmp icmpv6 type nd-redirect counter accept
 
   icmpv6_in_drop_redirect:
 
     # RFC 4890, 4.4.4.  Traffic for Which a Policy Should Be Defined
 
-    - meta l4proto ipv6-icmp icmpv6 type nd-redirect ip6 counter drop
+    - meta l4proto ipv6-icmp icmpv6 type nd-redirect counter drop
 
   icmpv6_in_allow_nodeinfo:
 


### PR DESCRIPTION
Currently those rules gives the following error:
```
# nft -c -f /etc/nftables.conf
In file included from /etc/nftables.conf:20:2-44:
/etc/nftables.d/filter-input.nft:51:53-59: Error: syntax error, unexpected counter
	meta l4proto ipv6-icmp icmpv6 type nd-redirect ip6 counter accept
	                                                   ^^^^^^^
```