### PR TITLE
Make starting the service optional for containerized etc. setups

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ complexify his philosophy… (I'm pretty sure, i now did complexify it :D) ^^
 * **nft_define_group** : You can add vars or override those defined by **nft_define_default** and **nft_define** for a group.
 * **nft_define_host** : You can add or override all previous vars.
 * **nft_service_manage** : If `nftables` service should be managed with this role [default : `true`].
+* **nft_service_started** : If `nftables` service should be started and restarted by this role [default : `true`].
 * **nft_service_name** : `nftables` service name [default : `nftables`].
 * **nft_service_enabled** : Set `nftables` service available at startup [default : `true`].
 * **nft__service_protect** : If systemd unit should protect system and home [default : `true`].

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -538,11 +538,22 @@ nft__nat_postrouting_conf_content: 'etc/nftables.d/nat-postrouting.nft.j2'
 # If the Nftables service should be managed ? Possible options are :
 #
 # ``True``
-#   Default. The service is started.
+#   Default. The service is managed.
 #
 # ``False``
 #   The service will not be touched.
 nft_service_manage: true
+
+# .. envvar:: nft_service_manage [[[
+#
+# If the Nftables service should be managed ? Possible options are :
+#
+# ``True``
+#   Default. The service is started and reloaded.
+#
+# ``False``
+#   The service will not be started or reloaded.
+nft_service_started: true
                                                                    # ]]]
 # .. envvar:: nft_service_name [[[
 #

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -12,7 +12,7 @@
     name: '{{ nft_service_name }}'
   async: 5
   poll: 2
-  when: ansible_service_mgr == 'systemd' and nft_service_manage
+  when: ansible_service_mgr == 'systemd' and nft_service_manage and nft_service_started
 
 # Reload will avoid to loose Nftables rulebase if an invalid syntax is added
 - name: Reload nftables service
@@ -23,4 +23,5 @@
   poll: 2
   when: ansible_service_mgr == 'systemd' and
         nft_service_manage and
-        not nftables__register_systemd_service.changed
+        not nftables__register_systemd_service.changed and
+        nft_service_started

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -258,10 +258,9 @@
     - nft_service_manage|bool
   notify: ['Restart nftables service']
 
-# Manage nftables service [[[1
-- name: Manage nftables service
+# Enable nftables service [[[1
+- name: Enable nftables service
   ansible.builtin.systemd:
-    state: 'started'
     name: '{{ nft_service_name }}'
     enabled: '{{ nft_service_enabled }}'
   async: 10
@@ -270,3 +269,16 @@
     - not ansible_check_mode
     - ansible_service_mgr == 'systemd'
     - nft_service_manage
+
+# Start nftables service [[[1
+- name: Start nftables service
+  ansible.builtin.systemd:
+    state: 'started'
+    name: '{{ nft_service_name }}'
+  async: 10
+  poll: 2
+  when:
+    - not ansible_check_mode
+    - ansible_service_mgr == 'systemd'
+    - nft_service_manage
+    - nft_service_started


### PR DESCRIPTION
This PR decouples enabling and starting of the systemd service.

We're building container images that will be launched via [Warewulf](https://warewulf.org/) and during the image building process systemd services cannot be started. This PR makes it possible to enable the service without starting it via additional environment variable `nft_service_started`.

Default of this variable is `true`, so people who use `nft_service_manage: true` will get similar behavior as before.