### PR TITLE
extend nft_flush_target to nft_flush_cmd

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -137,11 +137,11 @@ nft_main_conf_content: 'etc/nftables.conf.j2'
                                                                    # ]]]
 # .. envvar:: nft_main_conf_content [[[
 #
-# Target of rules to flush on restart.
+# Flush command on restart.
 #
-# Must be a valid target, like "ruleset", "table <mytable>", or
-# "chain <mytable> <mychain>"
-nft_flush_target: 'ruleset'
+# Must be a valid nft command, like "flush ruleset", "destroy table <mytable>", or
+# "destroy chain <mytable> <mychain>"
+nft_flush_cmd: 'flush ruleset'
                                                                    # ]]]
 # Nftables vars definition [[[
 # ----------------------------

--- a/templates/etc/nftables.conf.j2
+++ b/templates/etc/nftables.conf.j2
@@ -10,7 +10,7 @@
 {% set _ = globalmerged.update(nft_global_host_rules) %}
 
 # clean
-flush {{ nft_flush_target }}
+{{ nft_flush_cmd }}
 
 include "{{ nft_define_conf_path }}"
 

--- a/templates/etc/systemd/system/nftables.service.j2
+++ b/templates/etc/systemd/system/nftables.service.j2
@@ -15,7 +15,7 @@ ProtectSystem=full
 ProtectHome=true
 ExecStart={{ nft__bin_location }} -f {{ nft_main_conf_path }}
 ExecReload={{ nft__bin_location }} -f {{ nft_main_conf_path }}
-ExecStop={{ nft__bin_location }} flush {{ nft_flush_target }}
+ExecStop={{ nft__bin_location }} {{ nft_flush_cmd }}
 
 [Install]
 WantedBy=sysinit.target


### PR DESCRIPTION
When using just a 'target' and you want to preserve some custom tables you might want to change the behavior of this role to just handle the 'inet filter' table.

But running 'flush table inet filter' will not remove the filter table as it is done with the default 'flush ruleset'. Instead this will just flush the rules and sets and chains would be preserved and maybe leading to undesired side effects.

This commit extends the variable to hold a complete command so you can use 'destroy' on a table instead of 'flush' so the filter table is rebuild from the ground up on restart.