### PR TITLE
make forward rule generator respect `nft_backup_conf`

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -163,7 +163,7 @@
     owner: root
     group: root
     mode: 0600
-    backup: yes
+    backup: "{{ nft_backup_conf }}"
   notify: ['Reload nftables service']
   when: (nft_enabled|bool and
          nft__forward_table_manage|bool)


### PR DESCRIPTION
Replaces `backup: yes` with `backup: "{{ nft_backup_conf }}"`

Resolves #76 