### PR TITLE
Reapply PR#58: use `inet` table for NAT

### DIFF
--- a/templates/etc/nftables.conf.j2
+++ b/templates/etc/nftables.conf.j2
@@ -49,7 +49,7 @@ table inet filter {
 
 {% if nft__nat_table_manage %}
 # Additionnal table for Network Address Translation (NAT)
-table ip nat {
+table inet nat {
 	include "{{ nft_conntrack_conf_path }}"
 	include "{{ nft_set_conf_path }}"
 	include "{{ nft__nat_prerouting_conf_path }}"


### PR DESCRIPTION
Reapply https://github.com/ipr-cnrs/nftables/pull/58 which was unintentionally undone

Use `inet` table for NAT instead of `ip` so that IPv6 NAT rules (redirects etc.) can be applied.