### PR TITLE
Provide the ability to adjust async timeout on both restart/reload handlers

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -787,6 +787,22 @@ nft__service_override_content: 'etc/systemd/system/nftables.service.d/override.c
 #   The directives will be ignored.
 nft__service_protect: true
                                                                    # ]]]
+# .. envvar:: nft_service_restart_async_timeout [[[
+#
+# There are some cases where you may need to adjust the async setting
+# on hosts which have high latency to prevent timeouts. By default, this
+# setting is 5 (seconds).
+#
+nft_service_restart_async_timeout: 5
+                                                                   # ]]]
+# .. envvar:: nft_service_reload_async_timeout [[[
+#
+# There are some cases where you may need to adjust the async setting
+# on hosts which have high latency to prevent timeouts. By default, this
+# setting is 5 (seconds).
+#
+nft_service_reload_async_timeout: 5
+                                                                   # ]]]
 
 # .. envvar:: nft_fail2ban_service_override [[[
 #

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -10,7 +10,7 @@
                        (nftables__register_systemd_custom.changed | default(False)) }}'
     state: 'restarted'
     name: '{{ nft_service_name }}'
-  async: 5
+  async: '{{ nft_service_restart_async_timeout }}'
   poll: 2
   when:
     - not ansible_check_mode
@@ -22,7 +22,7 @@
   ansible.builtin.systemd:
     state: 'reloaded'
     name: '{{ nft_service_name }}'
-  async: 5
+  async: '{{ nft_service_reload_async_timeout }}'
   poll: 2
   when:
     - not ansible_check_mode


### PR DESCRIPTION
This resolves issue https://github.com/ipr-cnrs/nftables/issues/84

Tested on a few hosts which had >220ms latency, no issues.