### PR TITLE
remove async from systemd service handling

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -10,8 +10,6 @@
                        (nftables__register_systemd_custom.changed | default(False)) }}'
     state: 'restarted'
     name: '{{ nft_service_name }}'
-  async: 5
-  poll: 2
   when:
     - not ansible_check_mode
     - ansible_service_mgr == 'systemd'
@@ -22,8 +20,6 @@
   ansible.builtin.systemd:
     state: 'reloaded'
     name: '{{ nft_service_name }}'
-  async: 5
-  poll: 2
   when:
     - not ansible_check_mode
     - ansible_service_mgr == 'systemd'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -310,8 +310,6 @@
     state: 'started'
     name: '{{ nft_service_name }}'
     enabled: '{{ nft_service_enabled }}'
-  async: 10
-  poll: 2
   when:
     - not ansible_check_mode
     - ansible_service_mgr == 'systemd'


### PR DESCRIPTION
The async/poll method introduced in #36 makes ansible hang if used with mitogen. As ansible blocks anyway when used with poll it seems removing async helps here, without loosing too much functionality.