### PR TITLE
Minor fixes of the condition to show "nft_combined_rules" and indent in some template

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,7 +41,7 @@
 - name: Debug nft_combined_rules
   ansible.builtin.debug:
     var: nft_combined_rules
-  when: nft_debug
+  when: (nft_debug and nft_combined_rules is defined)
 
 - name: Debug ansible_os_family
   ansible.builtin.debug:

--- a/templates/etc/nftables.d/defines.nft.j2
+++ b/templates/etc/nftables.d/defines.nft.j2
@@ -3,7 +3,7 @@
 {% set definemerged = nft_define_default.copy() %}
 {% set _ = definemerged.update(nft_define) %}
 {% set _ = definemerged.update(nft_define_group) %}
-{% if nft_merged_groups and hostvars[inventory_hostname]['nft_combined_rules'].nft_define_group is defined%}
+{% if nft_merged_groups and hostvars[inventory_hostname]['nft_combined_rules'].nft_define_group is defined %}
   {% set _ = definemerged.update(hostvars[inventory_hostname]['nft_combined_rules'].nft_define_group) %}
 {% endif %}
 {% set _ = definemerged.update(nft_define_host) %}


### PR DESCRIPTION
The fix in condition fixes such minor error in molecule outout
```
  │ TASK [nftables : Debug nft_combined_rules] *************************************
  │ [WARNING]: Encountered 1 template error.
  │ error 1 - 'nft_combined_rules' is undefined
  │ Origin: <HIDDEN>/roles/nftables-mvk15/tasks/main.yml:43:10
  │
  │ 41 - name: Debug nft_combined_rules
  │ 42   ansible.builtin.debug:
  │ 43     var: nft_combined_rules
  │             ^ column 10
```